### PR TITLE
update Transform.isObject to filter nulls

### DIFF
--- a/src/utils/datatransform.ts
+++ b/src/utils/datatransform.ts
@@ -229,6 +229,6 @@ export class Transform {
     }
 
     static isObject(data: any) {
-        return typeof data === 'object';
+        return data !== null && typeof data === 'object';
     }
 }


### PR DESCRIPTION
Right now `isObject` returns true for `null`, this is causing `Object.entries(value)` to break with `Uncaught TypeError: Cannot convert undefined or null to object`